### PR TITLE
Improve ignored users

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,23 +21,17 @@ const channelIDs = {
   '#t/S/l/pr': 'ee715867-d978-447b-a4fd-95071b1dbcef'
 }
 
-// user.html_urlで指定
+// user.loginで指定
 // コメントが追加/編集されてもメッセージ投稿しないユーザー
 const commentIgnoredUsers = [
-  'https://github.com/apps/dependabot',
-  'https://github.com/apps/dependabot-preview',
-  'https://github.com/apps/codecov'
+  'dependabot[bot]',
+  'dependabot-preview[bot]',
+  'codecov[bot]'
 ]
 // PRの本文を省略するユーザー
-const prBodyOmittedUsers = [
-  'https://github.com/apps/dependabot',
-  'https://github.com/apps/dependabot-preview'
-]
+const prBodyOmittedUsers = ['dependabot[bot]', 'dependabot-preview[bot]']
 // PRの編集がされてもメッセージを投稿しないユーザー
-const prEditIgnoredUsers = [
-  'https://github.com/apps/dependabot',
-  'https://github.com/apps/dependabot-preview'
-]
+const prEditIgnoredUsers = ['dependabot[bot]', 'dependabot-preview[bot]']
 
 const verifyBody = (secret, signature, payload) => {
   const sign = `sha1=${crypto
@@ -98,7 +92,7 @@ const createText = (title, headData, content) => {
 }
 
 const omitIfNeeded = (user, content) =>
-  !prBodyOmittedUsers.includes(user.html_url) ? content : undefined
+  !prBodyOmittedUsers.includes(user.login) ? content : undefined
 
 export const webhook = async (req, res) => {
   const headers = req.headers
@@ -207,7 +201,7 @@ export const webhook = async (req, res) => {
     const user = comment.user
     const content = format(comment.body)
 
-    if (commentIgnoredUsers.includes(user.html_url)) {
+    if (commentIgnoredUsers.includes(user.login)) {
       res.send('OK')
       return
     }
@@ -229,7 +223,7 @@ export const webhook = async (req, res) => {
     const user = comment.user
     const content = format(comment.body)
 
-    if (commentIgnoredUsers.includes(user.html_url)) {
+    if (commentIgnoredUsers.includes(user.login)) {
       res.send('OK')
       return
     }
@@ -266,7 +260,7 @@ export const webhook = async (req, res) => {
     const user = pr.user
     const content = format(pr.body)
 
-    if (prEditIgnoredUsers.includes(user.html_url)) {
+    if (prEditIgnoredUsers.includes(user.login)) {
       res.send('OK')
       return
     }

--- a/app.js
+++ b/app.js
@@ -22,16 +22,19 @@ const channelIDs = {
 }
 
 // user.loginで指定
+const isAppBot = loginName => loginName.endsWith('[bot]')
 // コメントが追加/編集されてもメッセージ投稿しないユーザー
-const commentIgnoredUsers = [
-  'dependabot[bot]',
-  'dependabot-preview[bot]',
-  'codecov[bot]'
-]
+const commentIgnoredUsers = [isAppBot]
 // PRの本文を省略するユーザー
-const prBodyOmittedUsers = ['dependabot[bot]', 'dependabot-preview[bot]']
+const prBodyOmittedUsers = [isAppBot]
 // PRの編集がされてもメッセージを投稿しないユーザー
-const prEditIgnoredUsers = ['dependabot[bot]', 'dependabot-preview[bot]']
+const prEditIgnoredUsers = [isAppBot]
+
+const ignore = (loginName, ignoreList) =>
+  ignoreList.some(ignore => {
+    if (typeof ignore === 'function') return ignore(loginName)
+    else return ignore === loginName
+  })
 
 const verifyBody = (secret, signature, payload) => {
   const sign = `sha1=${crypto
@@ -92,7 +95,7 @@ const createText = (title, headData, content) => {
 }
 
 const omitIfNeeded = (user, content) =>
-  !prBodyOmittedUsers.includes(user.login) ? content : undefined
+  !ignore(user.login, prBodyOmittedUsers) ? content : undefined
 
 export const webhook = async (req, res) => {
   const headers = req.headers
@@ -201,7 +204,7 @@ export const webhook = async (req, res) => {
     const user = comment.user
     const content = format(comment.body)
 
-    if (commentIgnoredUsers.includes(user.login)) {
+    if (ignore(user.login, commentIgnoredUsers)) {
       res.send('OK')
       return
     }
@@ -223,7 +226,7 @@ export const webhook = async (req, res) => {
     const user = comment.user
     const content = format(comment.body)
 
-    if (commentIgnoredUsers.includes(user.login)) {
+    if (ignore(user.login, commentIgnoredUsers)) {
       res.send('OK')
       return
     }
@@ -260,7 +263,7 @@ export const webhook = async (req, res) => {
     const user = pr.user
     const content = format(pr.body)
 
-    if (prEditIgnoredUsers.includes(user.login)) {
+    if (ignore(user.login, prEditIgnoredUsers)) {
       res.send('OK')
       return
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "prettier": "^2.5.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@eslint/eslintrc": {


### PR DESCRIPTION
'[bot]' が末尾についていたら省略するように
dependabot, codecovに加えて、renovate(独自app)も使うようになってきたので
例: https://github.com/traPtitech/manifest/pull/46

GitHub Appの場合はlogin nameの末尾に[bot]がつく
https://github.com/orgs/community/discussions/26560